### PR TITLE
removed faulty function dependencies

### DIFF
--- a/GeneralHealthBots/includes/f_Confirm_Question.ahk
+++ b/GeneralHealthBots/includes/f_Confirm_Question.ahk
@@ -18,7 +18,7 @@
 	GuiControl, Focus, %b2%
 	SendInput, {Left}{Right}
 	WinWaitClose
-	ttip(f_cQ_Callback)
+	;ttip(f_cQ_Callback)
 	return {(b):1, (b2):0, (b3):-1}[f_cQ_Callback]
 }
 f_cQ_Callback()

--- a/Updater.ahk
+++ b/Updater.ahk
@@ -51,7 +51,7 @@
 	Gui, destroy
 	SetTitleMatchMode, 2
 	WinGetActiveTitle, acttit
-	m(acttit)
+	msgbox, % acttit
 	if WinActive("Visual Studio Code")
 		vsdb:=true ; activate 
 	else 
@@ -256,7 +256,7 @@ f_PerformUpdate(ReturnPackage,GitPageURLComponents,LocalValues,VersionNumberDefS
 	; 0. Create Backup
 	if vNumberOfBackups>0
 	{
-		m(LocalValues)
+		;m(LocalValues)
 		f_CreateBackup(vNumberOfBackups,LocalValues[5])
 	}
 	; 1. Parse throught ReturnPackage[2]
@@ -345,7 +345,7 @@ f_WriteFilesFromArray(ReturnPackage,FileTexts,GitPageURLComponents,VersionNumber
 	; IniObj["local"]:=ReturnPackage[3]
 	; and now we only have to write the files to the files, duh.
 	if !vsdb
-		msgbox, "f_writeFilesFromArray:`nremember to finish thee notify-msgs"
+		msgbox, % A_ThisFunc ":`nremember to finish thee notify-msgs"
 		
 	f_FinishUp(GitPageURLComponents,Files)
 }


### PR DESCRIPTION
Removed call to non-included `m.ahk` and `ttip.ahk` which shouldn't ever be in the public version. Sloppy cleanup work a few months back.